### PR TITLE
Check for cancelled language before including an OH event

### DIFF
--- a/qiocli/utils.py
+++ b/qiocli/utils.py
@@ -25,7 +25,8 @@ def form_schedule(events):
     items = events['items']
     oh_sessions = filter(
         lambda x: x['status'] != 'cancelled' and 'Office Hours'
-        in x['summary'], items)
+        in x['summary'] and not ('Cancelled' in x['summary']
+                                 or 'No' in x['summary']), items)
     oh_sessions = list(oh_sessions)
     oh_sessions = [
         {


### PR DESCRIPTION
I ran into some problems with the office hours workflows because we had "No Office Hours" all-day events on the calendar that broke the indexing pattern. My workaround was changing the event to "OH" instead of "Office Hours," but I think it makes sense to check for cancellation language always. 

This changes the filter for selecting office hours events from the calendar to also look for (and exclude) "No [Office Hours]" or "[Office Hours Cancelled]".